### PR TITLE
Use options interface that includes selector for extend queries

### DIFF
--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -48,7 +48,10 @@ interface IQueryMethods {
 }
 
 type IScopedQueryMethods = {
-  [K in keyof IQueryMethods]: (m: Matcher, opts?: MatcherOptions) => ReturnType<IQueryMethods[K]>
+  [K in keyof IQueryMethods]: (
+    m: Matcher,
+    opts?: Parameters<IQueryMethods[K]>[2],
+  ) => ReturnType<IQueryMethods[K]>
 }
 
 export interface IScopedQueryUtils extends IScopedQueryMethods {

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -80,6 +80,23 @@ describe('lib/extend.ts', () => {
     expect(text).toEqual(['Hello h1', 'Hello h2', 'Hello h3'])
   })
 
+  it('should handle the queryAll* methods with a selector', async () => {
+    const elements = await document.queryAllByText(/Hello/, {selector: 'h2'})
+    expect(elements).toHaveLength(1)
+
+    const text = await page.evaluate(el => el.textContent, elements[0])
+
+    expect(text).toEqual('Hello h2')
+  })
+
+  it('should handle the getBy* methods with a selector', async () => {
+    const element = await document.getByText(/Hello/, {selector: 'h2'})
+
+    const text = await page.evaluate(el => el.textContent, element)
+
+    expect(text).toEqual('Hello h2')
+  })
+
   it('should scope results to element', async () => {
     const scope = await document.$('#scoped')
     const element = await scope!.queryByText(/Hello/)


### PR DESCRIPTION
Ensure scoped query methods that accept a `selector` option have the correct type for the `options` parameter (`SelectorMatcherOptions` instead of `MatcherOptions` from **@testing-library/dom**).