### PR TITLE
Nested RegExp and proper options type for role queries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,4 +7,8 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['tsconfig.eslint.json', 'tsconfig.json'],
   },
+  rules: {
+    'no-restricted-syntax': 'off',
+    'no-underscore-dangle': ['error', {allow: ['__regex', '__flags']}],
+  },
 }

--- a/lib/extend.ts
+++ b/lib/extend.ts
@@ -15,10 +15,10 @@ function requireOrUndefined(path: string): any {
 }
 
 try {
-  Page = require('playwright/lib/page.js') // tslint:disable-line
+  Page = require('playwright/lib/page.js')
   if (Page.Page) Page = Page.Page
 
-  ElementHandle = requireOrUndefined('playwright/lib/api.js') // tslint:disable-line variable-name
+  ElementHandle = requireOrUndefined('playwright/lib/api.js')
   if (ElementHandle && ElementHandle.ElementHandle) ElementHandle = ElementHandle.ElementHandle
 
   Page.prototype.getDocument = getDocument
@@ -35,7 +35,6 @@ try {
   throw err
 }
 
-/* tslint:disable */
 declare module 'playwright/types/types' {
   interface Page {
     getDocument(): Promise<ElementHandle>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,14 +11,40 @@ const domLibraryAsString = readFileSync(
 ).replace(/process.env/g, '{}')
 
 /* istanbul ignore next */
-function mapArgument(argument: any, index: number): any {
-  return index === 0 && typeof argument === 'object' && argument.regex
-    ? new RegExp(argument.regex, argument.flags)
-    : argument
+function convertProxyToRegExp(o: any, depth: number): any {
+  if (typeof o !== 'object' || !o || depth > 2) return o
+  if (!o.__regex || typeof o.__flags !== 'string') {
+    const copy = {...o}
+    for (const key of Object.keys(copy)) {
+      copy[key] = convertProxyToRegExp(copy[key], depth + 1)
+    }
+    return copy
+  }
+
+  return new RegExp(o.__regex, o.__flags)
+}
+
+/* istanbul ignore next */
+function mapArgument(o: any): any {
+  return convertProxyToRegExp(o, 0)
+}
+
+function convertRegExpToProxy(o: any, depth: number): any {
+  if (typeof o !== 'object' || !o || depth > 2) return o
+  if (!(o instanceof RegExp)) {
+    const copy = {...o}
+    for (const key of Object.keys(copy)) {
+      copy[key] = convertRegExpToProxy(copy[key], depth + 1)
+    }
+    return copy
+  }
+
+  return {__regex: o.source, __flags: o.flags}
 }
 
 const delegateFnBodyToExecuteInPageInitial = `
   ${domLibraryAsString};
+  ${convertProxyToRegExp.toString()};
 
   const mappedArgs = args.map(${mapArgument.toString()});
   const moduleWithFns = fnName in __dom_testing_library__ ?
@@ -97,8 +123,6 @@ function createDelegateFor<T = DOMReturnType>(
   // eslint-disable-next-line no-param-reassign
   processHandleFn = processHandleFn || processQuery
 
-  const convertRegExp = (regex: RegExp) => ({regex: regex.source, flags: regex.flags})
-
   return async function delegate(...args: any[]): Promise<T> {
     // @ts-ignore
     const containerHandle: ElementHandle = contextFn ? contextFn.apply(this, args) : this
@@ -107,12 +131,14 @@ function createDelegateFor<T = DOMReturnType>(
     // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
     const evaluateFn = new Function('container, [fnName, ...args]', delegateFnBodyToExecuteInPage)
 
-    // Convert RegExp to a special format since they don't serialize well
-    let argsToForward = args.map(arg => (arg instanceof RegExp ? convertRegExp(arg) : arg))
+    let argsToForward = args
     // Remove the container from the argsToForward since it's always the first argument
     if (containerHandle === args[0]) {
       argsToForward = argsToForward.slice(1)
     }
+
+    // Convert RegExp to a special format since they don't serialize well
+    argsToForward = argsToForward.map(convertRegExpToProxy)
 
     return processHandleFn!({fnName, containerHandle, evaluateFn, argsToForward})
   }

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -1,9 +1,27 @@
-import {Matcher, MatcherOptions, SelectorMatcherOptions, waitForOptions} from '@testing-library/dom'
+import {
+  Matcher,
+  MatcherOptions as MatcherOptions_,
+  SelectorMatcherOptions as SelectorMatcherOptions_,
+  waitForOptions,
+} from '@testing-library/dom'
 import {ElementHandle as PlaywrightElementHandle} from 'playwright'
 
 export type ElementHandle = PlaywrightElementHandle<SVGElement | HTMLElement>
 
 type Element = ElementHandle
+
+type MatcherOptions = Omit<MatcherOptions_, 'normalizer'>
+type SelectorMatcherOptions = Omit<SelectorMatcherOptions_, 'normalizer'>
+
+// tslint:disable-next-line
+interface RoleMatcherOptions extends MatcherOptions {
+  name?: string | RegExp
+}
+
+// tslint:disable-next-line
+interface SelectorRoleMatcherOptions extends SelectorMatcherOptions {
+  name?: string | RegExp
+}
 
 interface IQueryMethods {
   queryByPlaceholderText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
@@ -108,20 +126,20 @@ interface IQueryMethods {
     waitForOpts?: waitForOptions,
   ): Promise<Element[]>
 
-  queryByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
-  queryAllByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
-  getByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
-  getAllByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  queryByRole(el: Element, m: Matcher, opts?: RoleMatcherOptions): Promise<Element | null>
+  queryAllByRole(el: Element, m: Matcher, opts?: RoleMatcherOptions): Promise<Element[]>
+  getByRole(el: Element, m: Matcher, opts?: RoleMatcherOptions): Promise<Element>
+  getAllByRole(el: Element, m: Matcher, opts?: RoleMatcherOptions): Promise<Element[]>
   findByRole(
     el: Element,
     m: Matcher,
-    opts?: SelectorMatcherOptions,
+    opts?: SelectorRoleMatcherOptions,
     waitForOpts?: waitForOptions,
   ): Promise<Element>
   findAllByRole(
     el: Element,
     m: Matcher,
-    opts?: SelectorMatcherOptions,
+    opts?: SelectorRoleMatcherOptions,
     waitForOpts?: waitForOptions,
   ): Promise<Element[]>
 
@@ -150,8 +168,8 @@ export type BoundFunction<T> = T extends (
   options: infer Q,
 ) => infer R
   ? (text: P, options?: Q) => R
-  : T extends (a1: any, text: infer P, options: infer Q, waitForElementOptions: infer W) => infer R
-  ? (text: P, options?: Q, waitForElementOptions?: W) => R
+  : T extends (a1: any, text: infer P, options: infer Q, waitForOptions: infer W) => infer R
+  ? (text: P, options?: Q, waitForOptions?: W) => R
   : T extends (a1: any, text: infer P, options: infer Q) => infer R
   ? (text: P, options?: Q) => R
   : never

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -13,12 +13,10 @@ type Element = ElementHandle
 type MatcherOptions = Omit<MatcherOptions_, 'normalizer'>
 type SelectorMatcherOptions = Omit<SelectorMatcherOptions_, 'normalizer'>
 
-// tslint:disable-next-line
 interface RoleMatcherOptions extends MatcherOptions {
   name?: string | RegExp
 }
 
-// tslint:disable-next-line
 interface SelectorRoleMatcherOptions extends SelectorMatcherOptions {
   name?: string | RegExp
 }

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -98,6 +98,14 @@ describe('lib/extend.ts', () => {
     expect(text).toEqual('Hello h2')
   })
 
+  it('should handle the getBy* methods with a regex name', async () => {
+    const element = await document.getByRole('button', {name: /getBy.*Test/})
+
+    const text = await page.evaluate(el => el.textContent, element)
+
+    expect(text).toEqual('getByRole Test')
+  })
+
   it('should scope results to element', async () => {
     const scope = await document.$('#scoped')
     const element = await scope!.queryByText(/Hello/)

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -9,6 +9,7 @@
   <label for="label-text-input" data-testid="testid-label">Label A</label>
   <input id="label-text-input" type="text">
 
+  <button role="button">getByRole Test</button>
   <div id="scoped">
     <h3>Hello h3</h3>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,9 +1161,9 @@
     "@babel/plugin-transform-react-pure-annotations" "^7.10.1"
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz#f29fc1990307c4c57b10dbd6ce667b27159d9e0d"
-  integrity sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
   dependencies:
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"


### PR DESCRIPTION
- Port nested RegExp feature from upstream
- Port _correct_ `RoleMatcherOptions` for upgraded **@testing-library/dom** from upstream (thanks @patrickhulce! I totally missed this)