### PR TITLE
fix: modify how RegExp matchers are identified

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,7 +31,7 @@ function mapArgument(o: any): any {
 
 function convertRegExpToProxy(o: any, depth: number): any {
   if (typeof o !== 'object' || !o || depth > 2) return o
-  if (!(o instanceof RegExp)) {
+  if (!o.constructor.toString().includes('function RegExp()')) {
     const copy = {...o}
     for (const key of Object.keys(copy)) {
       copy[key] = convertRegExpToProxy(copy[key], depth + 1)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.3.1",
     "@types/jest": "^26.0.4",
+    "await-outside": "^3.0.0",
     "generate-export-aliases": "^1.1.0",
     "jest": "^25.1.0",
     "playwright": "^1.1.0",

--- a/test/edgeCases/repl.test.ts
+++ b/test/edgeCases/repl.test.ts
@@ -1,0 +1,80 @@
+import './types.d'
+import * as path from 'path'
+import * as playwright from 'playwright'
+import * as repl from 'repl'
+import * as stream from 'stream'
+
+import {addAwaitOutsideToReplServer} from 'await-outside'
+
+import {configure, queries} from '../../lib'
+
+describe('edge case', () => {
+  let browser: playwright.Browser
+  let page: playwright.Page
+
+  beforeAll(async () => {
+    browser = await playwright.chromium.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']})
+    page = await browser.newPage()
+    await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
+  })
+
+  const inputStream = new stream.Readable()
+  // eslint-disable-next-line
+  inputStream._read = () => {}
+
+  let outputStr = ''
+  const through = new stream.PassThrough()
+  const outputStream = new stream.Writable()
+  // eslint-disable-next-line
+  outputStream._write = function (chunk, encoding, done) {
+    outputStr = `${outputStr}${chunk.toString()}`
+    done()
+  }
+
+  through.pipe(outputStream)
+
+  it('fails to evaluate regexes when included in repl context', async () => {
+    const replServer = repl.start({
+      terminal: false,
+      useColors: false,
+      useGlobal: true,
+      output: through,
+      input: inputStream,
+    })
+    addAwaitOutsideToReplServer(replServer)
+
+    replServer.context.page = page
+    replServer.context.queries = queries
+
+    const commands = ["await queries.getByText(await page.$('#scoped'), /Hello/);", '.exit']
+
+    commands.forEach(command => {
+      inputStream.push(command)
+      inputStream.push('\r')
+    })
+    inputStream.push(null)
+
+    replServer.on('exit', () => {
+      setTimeout(() => {
+        through.end()
+        outputStream.end()
+      }, 1500)
+    })
+
+    await new Promise(resolve => {
+      outputStream.on('finish', () => {
+        expect(outputStr).toMatch('ElementHandle')
+        expect(outputStr).not.toMatch('matcher.test is not a function')
+        resolve()
+      })
+    })
+  })
+
+  afterEach(() => {
+    configure({testIdAttribute: 'data-testid'}) // cleanup
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+})

--- a/test/edgeCases/types.d.ts
+++ b/test/edgeCases/types.d.ts
@@ -1,0 +1,6 @@
+declare module 'await-outside' {
+  import {REPLServer} from 'repl'
+
+  // eslint-disable-next-line
+  export function addAwaitOutsideToReplServer(repl: REPLServer): void
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,14 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async-to-gen@~1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-to-gen/-/async-to-gen-1.3.3.tgz#d52c9fb4801f0df44abc4d2de1870b48b60e20bb"
+  integrity sha1-1SyftIAfDfRKvE0t4YcLSLYOILs=
+  dependencies:
+    babylon "^6.14.0"
+    magic-string "^0.19.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2866,6 +2874,13 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+await-outside@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/await-outside/-/await-outside-3.0.0.tgz#cf97dff66dbb6fe635935e541f40d676464f0a6d"
+  integrity sha512-ZIxAOB+YJvmzUR4VKVX+SWtdlXfNUAv0fkZWZvtz12A5lexesibQDeiK+XhPanA6DMCscuT+9tZ3OBIPGTmZ7A==
+  dependencies:
+    async-to-gen "~1.3.2"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3084,6 +3099,11 @@ babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babylon@^6.14.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 bail@^1.0.0:
   version "1.0.5"
@@ -7676,6 +7696,13 @@ ltgt@^2.1.2:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
 
+magic-string@^0.19.0:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.1.tgz#14d768013caf2ec8fdea16a49af82fc377e75201"
+  integrity sha1-FNdoATyvLsj96hakmvgvw3fnUgE=
+  dependencies:
+    vlq "^0.2.1"
+
 magic-string@^0.22.5:
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
@@ -10706,7 +10733,7 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-vlq@^0.2.2:
+vlq@^0.2.1, vlq@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
   integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==


### PR DESCRIPTION
This is an edge case I found while playing with https://github.com/qawolf/qawolf and https://github.com/hoverinc/playwright-testing-library.

In my particular case, I was adding `playwright-testing-library` queries to the `repl` context.

```ts
import * as pwt from 'playwright-testing-library';

// ....
export const repl = (context?: Record<string, unknown>) =>
  qawolf.repl({
    ...pwt.queries,
  });
```

That would cause `RegExp` created inside `repl` to no longer be identified as such [here](https://github.com/hoverinc/playwright-testing-library/blob/master/lib/index.ts#L34).

![image](https://user-images.githubusercontent.com/379034/94277766-6662aa80-ff20-11ea-97b7-9e6714fc7d78.png)


I modified the implementation to verify the constructor as this seems to be enough. 
I added a test to reproduce the issue with `repl`.