### PR TITLE
💚 Upgrade Playwright to 1.9 + improve error output

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -98,7 +98,9 @@ async function processQuery(handles: IHandleSet): Promise<DOMReturnType> {
     const handle = await containerHandle.evaluateHandle(evaluateFn, [fnName, ...argsToForward])
     return await covertToElementHandle(handle, fnName.includes('All'))
   } catch (err) {
-    err.message = err.message.replace('[fnName]', `[${fnName}]`)
+    err.message = err.message
+      .replace(/^.*(?=TestingLibraryElementError:)/, '')
+      .replace('[fnName]', `[${fnName}]`)
     err.stack = err.stack.replace('[fnName]', `[${fnName}]`)
     throw err
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^26.0.4",
     "generate-export-aliases": "^1.1.0",
     "jest": "^25.1.0",
-    "playwright": "^1.4.2",
+    "playwright": "^1.9.1",
     "rollup": "^2.0.3",
     "ts-jest": "^25.2.1",
     "typescript": "^3.9.6"

--- a/test/__snapshots__/extend.test.ts.snap
+++ b/test/__snapshots__/extend.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`lib/extend.ts should handle the LabelText methods 1`] = `"<input id=\\"label-text-input\\" type=\\"text\\">"`;
 
 exports[`lib/extend.ts should handle the get* method failures 1`] = `
-"TestingLibraryElementError: Unable to find an element with the title: missing.
+TestingLibraryElementError: Unable to find an element with the title: missing.
 
 <div
-  id=\\"scoped\\"
+  id="scoped"
 >
   
     
@@ -16,7 +16,7 @@ exports[`lib/extend.ts should handle the get* method failures 1`] = `
   
   
 </div>
-    <stack>:X:X"
+    <stack>:X:X
 `;
 
 exports[`lib/extend.ts should handle the get* methods 1`] = `"<input type=\\"text\\" data-testid=\\"testid-text-input\\">"`;

--- a/test/__snapshots__/extend.test.ts.snap
+++ b/test/__snapshots__/extend.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`lib/extend.ts should handle the LabelText methods 1`] = `"<input id=\\"label-text-input\\" type=\\"text\\">"`;
 
 exports[`lib/extend.ts should handle the get* method failures 1`] = `
-"Evaluation failed: TestingLibraryElementError: Unable to find an element with the title: missing.
+"TestingLibraryElementError: Unable to find an element with the title: missing.
 
 <div
   id=\\"scoped\\"

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -1,6 +1,10 @@
 import * as path from 'path'
 import * as playwright from 'playwright'
 
+import stacktraceSerializer from './serializers/stacktrace'
+
+expect.addSnapshotSerializer(stacktraceSerializer)
+
 describe('lib/extend.ts', () => {
   let browser: playwright.ChromiumBrowser
   let page: playwright.Page
@@ -52,14 +56,7 @@ describe('lib/extend.ts', () => {
     // Use the scoped element so the pretty HTML snapshot is smaller
     const scope = await document.$('#scoped')
 
-    try {
-      await scope!.getByTitle('missing')
-      fail() // eslint-disable-line jest/no-jasmine-globals
-    } catch (err) {
-      err.message = err.message.replace(/(\s*at .*(\n|$))+/gm, '\n    <stack>:X:X')
-      // eslint-disable-next-line jest/no-try-expect
-      expect(err.message).toMatchSnapshot()
-    }
+    await expect(async () => scope!.getByTitle('missing')).rejects.toThrowErrorMatchingSnapshot()
   })
 
   it('should handle the LabelText methods', async () => {

--- a/test/serializers/stacktrace.ts
+++ b/test/serializers/stacktrace.ts
@@ -1,0 +1,16 @@
+type Serializer = Parameters<typeof expect.addSnapshotSerializer>['0']
+
+const EXPRESSION = /(\s*at .*(\n|$))+/gm
+const PLACEHOLDER = '\n    <stack>:X:X'
+
+const serializer: Serializer = {
+  serialize(val) {
+    return typeof val === 'string' ? val.replace(EXPRESSION, PLACEHOLDER) : val
+  },
+
+  test(val) {
+    return typeof val === 'string' && EXPRESSION.test(val)
+  },
+}
+
+export default serializer

--- a/yarn.lock
+++ b/yarn.lock
@@ -8647,10 +8647,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright@^1.4.2:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.0.tgz#8eca2250967ee892b9fdfec44e2358455ab0f8e3"
-  integrity sha512-urMJDLX92KawbkWKrt3chVVBPQsuuNwlS5St7I5YQENXAEItoyUqX7FjiYaoPgXifKqe1+BKC+7pBAq1QUkgSw==
+playwright@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.9.1.tgz#b4db35f69076b2dc91e347e58d81f2f391d1ed49"
+  integrity sha512-bZXnks4UGJZoqja6TqVEUG0IQ2liqYFcO1R4lT43aO4oDVTQtawEJjS+EqLYsAuniRFWVE87Cemus4fRQbyXMg==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -8663,6 +8663,7 @@ playwright@^1.4.2:
     proper-lockfile "^4.1.1"
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
+    stack-utils "^2.0.3"
     ws "^7.3.1"
 
 please-upgrade-node@^3.2.0:
@@ -8772,11 +8773,11 @@ prop-types@^15.7.2:
     react-is "^16.8.1"
 
 proper-lockfile@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.1.tgz#284cf9db9e30a90e647afad69deb7cb06881262c"
-  integrity sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
   dependencies:
-    graceful-fs "^4.1.11"
+    graceful-fs "^4.2.4"
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
@@ -9858,6 +9859,13 @@ stack-utils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.2.tgz#5cf48b4557becb4638d0bc4f21d23f5d19586593"
   integrity sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
+stack-utils@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
+  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
 


### PR DESCRIPTION
- Upgrade Playwright to 1.9.1
- Strip any Playwright-related prefix (i.e: `jsHandle.evaluateHandle:` and `Evaluation Failed:`) from element errors
- Use snapshot serializer + snapshot error matcher instead of try/catch
