### PR TITLE
🐛 Fix callback type in `waitFor`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -155,8 +155,10 @@ export async function getDocument(_page?: Page): Promise<ElementHandle> {
   return document
 }
 
+type WaitForCallback = Parameters<typeof waitForExpect>[0]
+
 export function wait(
-  callback: () => void,
+  callback: WaitForCallback,
   {timeout = 4500, interval = 50}: {timeout?: number; interval?: number} = {},
 ): Promise<{}> {
   return waitForExpect(callback, timeout, interval)


### PR DESCRIPTION
Use type definition from library that provides \`waitFor\` functionality [**wait-for-expect**](https://github.com/TheBrainFamily/wait-for-expect) to type `callback` parameter of `waitFor`. This allows `async` functions to be passed as the `callback`.
