### PR TITLE
🛠 Update semver ranges for development dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   collectCoverageFrom: ['**/*.ts', '!**/*.d.ts'],
   coverageThreshold: {},
   setupFilesAfterEnv: ['./jest.setup.ts'],
+  testTimeout: 15000,
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "wait-for-expect": "^3.0.2"
   },
   "devDependencies": {
-    "@hover/javascript": "^6.16.0",
+    "@hover/javascript": "^6.53.0",
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
     "@rollup/plugin-replace": "^3.0.0",
@@ -51,7 +51,7 @@
     "generate-export-aliases": "^1.1.0",
     "husky": "^7.0.2",
     "playwright": "^1.11.0",
-    "rollup": "^2.0.3",
+    "rollup": "^2.58.0",
     "setimmediate": "^1.0.5",
     "typescript": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "playwright": "^1.11.0",
     "rollup": "^2.0.3",
     "setimmediate": "^1.0.5",
-    "ts-jest": "^27.0.3",
     "typescript": "^4.4.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,7 +5894,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-jest@^27.0.3, ts-jest@^27.0.5:
+ts-jest@^27.0.5:
   version "27.0.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.5.tgz#0b0604e2271167ec43c12a69770f0bb65ad1b750"
   integrity sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,7 +535,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@hover/javascript@^6.16.0":
+"@hover/javascript@^6.53.0":
   version "6.53.0"
   resolved "https://registry.yarnpkg.com/@hover/javascript/-/javascript-6.53.0.tgz#0baaa9dab1da109eef4d1696977466a6d4b57274"
   integrity sha512-RMfKTcdcUtAUsLYj9ZYPlV0GWtAZvkr9tVdliplMwCKn61GDvgoCEjiS8813y4CFjyOe7DoV20uiTMwaWkAZIg==
@@ -5316,7 +5316,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^2.0.3:
+rollup@^2.58.0:
   version "2.58.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.0.tgz#a643983365e7bf7f5b7c62a8331b983b7c4c67fb"
   integrity sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==
@@ -6003,7 +6003,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4, typescript@^4.4.3:
+typescript@^4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==


### PR DESCRIPTION
- Remove **ts-jest**, it's provided by **@hover/javascript** now
- Update semver ranges in package.json
